### PR TITLE
EmployeeAdminWithGXT build problem

### DIFF
--- a/EmployeeAdminWithGXT/pom.xml
+++ b/EmployeeAdminWithGXT/pom.xml
@@ -190,9 +190,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
         <version>2.6</version>
-        <configuration>
-          <warSourceDirectory>${basedir}/war</warSourceDirectory>
-        </configuration>
       </plugin>
 
       <!-- GWT Maven Plugin -->


### PR DESCRIPTION
mvn -X package command repors:

> org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-war-plugin:2.6:war (default-war) on project employeeadminwithgxt: Error assembling WAR: webxml attribute is required (or pre-existing WEB-INF/web.xml if executing in update mode)
